### PR TITLE
Fix theme toggle z-index conflict with navbar

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -8,7 +8,7 @@ const ThemeToggle = () => {
     <button
       onClick={toggleTheme}
       className={`
-        fixed top-6 right-6 z-50 p-3 rounded-full transition-all duration-300 ease-in-out
+        fixed top-6 right-6 z-[60] p-3 rounded-full transition-all duration-300 ease-in-out
         ${isDark 
           ? 'bg-slate-800/80 hover:bg-slate-700/80 text-yellow-400' 
           : 'bg-white/80 hover:bg-gray-100/80 text-slate-700'


### PR DESCRIPTION
- Increased z-index from z-50 to z-[60] to ensure theme toggle button appears above navbar elements
- Resolves issue where navbar SVG elements were intercepting click events
- Theme toggle now works correctly for switching between light and dark modes
- Maintains all existing functionality including theme persistence and smooth transitions